### PR TITLE
Update file writer example and optimized addSeparator function

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ t := tabby.NewCustom(w)
 ```
 
 ## Full Example
+- Default writer (os.Stdout) example:
 ```go
 package main
 
@@ -67,6 +68,29 @@ import "github.com/cheynewallace/tabby"
 
 func main() {
 	t := tabby.New()
+	t.AddHeader("NAME", "TITLE", "DEPARTMENT")
+	t.AddLine("John Smith", "Developer", "Engineering")
+	t.Print()
+}
+```
+
+- File writer example:
+```go
+package main
+
+import (
+	"os"
+	"text/tabwriter"
+	
+	"github.com/cheynewallace/tabby"
+)
+
+func main() {
+	fd, _ := os.OpenFile("test.txt", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	defer fd.Close()
+
+	w := tabwriter.NewWriter(fd, 0, 0, 4, ' ', 0)
+	t := tabby.NewCustom(w)
 	t.AddHeader("NAME", "TITLE", "DEPARTMENT")
 	t.AddLine("John Smith", "Developer", "Engineering")
 	t.Print()

--- a/tabby.go
+++ b/tabby.go
@@ -20,11 +20,9 @@ func New() *Tabby {
 	}
 }
 
-// NewCustom returns a new *Tabby with with custom *tabwriter.Writer set
+// NewCustom returns a new *Tabby with custom *tabwriter.Writer set
 func NewCustom(writer *tabwriter.Writer) *Tabby {
-	return &Tabby{
-		writer: writer,
-	}
+	return &Tabby{writer: writer}
 }
 
 // AddLine will write a new table line
@@ -55,7 +53,8 @@ func (t *Tabby) addSeparator(args []interface{}) {
 			b.WriteString("\t")
 		}
 	}
-	fmt.Fprintln(t.writer, b.String())
+	b.WriteString("\n")
+	b.WriteTo(t.writer)
 }
 
 // buildFormatString will build up the formatting string used by the *tabwriter.Writer

--- a/tabby_test.go
+++ b/tabby_test.go
@@ -90,6 +90,6 @@ func BenchmarkFmt(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var buff bytes.Buffer
 		buff.WriteString("TestString")
-		fmt.Fprintf(fd, buff.String())
+		fmt.Fprintln(fd, buff.String())
 	}
 }

--- a/tabby_test.go
+++ b/tabby_test.go
@@ -56,3 +56,40 @@ func Test_AddHeader(t *testing.T) {
 		t.Errorf("AddHeader not writing to io.Writer")
 	}
 }
+
+func Test_FileWriter(t *testing.T) {
+	fd, err := os.OpenFile("test.log", os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fd.Close()
+
+	w := tabwriter.NewWriter(fd, 0, 0, 4, ' ', 0)
+	tabby := NewCustom(w)
+	tabby.AddHeader("NAME", "TITLE", "DEPARTMENT")
+	tabby.AddLine("John Smith", "Developer", "Engineering")
+	tabby.Print()
+}
+
+func BenchmarkBuffer(b *testing.B) {
+	fd, _ := os.OpenFile("temp.txt", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	defer fd.Close()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var buff bytes.Buffer
+		buff.WriteString("TestString")
+		buff.WriteString("\n")
+		buff.WriteTo(fd)
+	}
+}
+
+func BenchmarkFmt(b *testing.B) {
+	fd, _ := os.OpenFile("temp.txt", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	defer fd.Close()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var buff bytes.Buffer
+		buff.WriteString("TestString")
+		fmt.Fprintf(fd, buff.String())
+	}
+}


### PR DESCRIPTION
1.[Remove repeat word 'with'](https://github.com/cheynewallace/tabby/blob/b7224f6123093cc04ce961170a360e1d22e214a5/tabby.go#L23)

2.Update file writer example to README.md

3.Update fmt.Fprintln to buffer.WriteTo

Source code:
```
// addSeparator will write a new dash seperator line based on the args length
func (t *Tabby) addSeparator(args []interface{}) {
	var b bytes.Buffer
	/*...*/
	fmt.Fprintln(t.writer, b.String())
}
```
After changed:
```
// addSeparator will write a new dash seperator line based on the args length
func (t *Tabby) addSeparator(args []interface{}) {
	var b bytes.Buffer
	/*...*/
	b.WriteString("\n")
	b.WriteTo(t.writer)
}
```

Why did I make this change? I added benchmark test code of fmt.Fprintln and buffer.WriteTo in tabby_test.go, benchmark test code like this:
```
func BenchmarkBuffer(b *testing.B) {
    fd, _ := os.OpenFile("temp.txt", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
	defer fd.Close()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		var buff bytes.Buffer
		buff.WriteString("TestString")
		buff.WriteString("\n")
		buff.WriteTo(fd)
	}
}

func BenchmarkFmt(b *testing.B) {
	fd, _ := os.OpenFile("temp.txt", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
	defer fd.Close()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		var buff bytes.Buffer
		buff.WriteString("TestString")
		fmt.Fprintln(fd, buff.String())
	}
}
```

Run benchmark test command:
```
$ go test -run=NONE -bench="^Benchmark(Fmt|Buffer)$" -benchmem
```
And I get benchmark test data:
```
$ go test -run=NONE -bench="^Benchmark(Fmt|Buffer)$" -benchmem
goos: windows
goarch: amd64
pkg: tabby
BenchmarkBuffer-4         300000              4460 ns/op             112 B/op          1 allocs/op
BenchmarkFmt-4            300000              5103 ns/op             112 B/op          1 allocs/op
PASS
ok      tabby   3.470s
```
We can see buffer.WriteTo is more effective than fmt.Fprintln.
